### PR TITLE
Enable Session API values replacement for body message

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ message is published. It can do publish with confirm mode turned on or
 off. It changes way of getting publish seq number and way of acknowledge
 from amqp server is done (sync or async).
 
+In message body, session values can be used for injecting dynamic data, 
+same behavior like gatling session API: http://gatling.io/docs/current/session/session_api/  
+
 ```
   implicit val amqpProtocol: AmqpProtocol = amqp
     .host("localhost")
@@ -38,10 +41,11 @@ from amqp server is done (sync or async).
     .auth("guest", "guest")
     .poolSize(10)    
 
-  val body = "{foo:1}")
+  val body = "{foo:1, bar: ${mykey}}")
   val queueName = "myQueue"
 
   val scn = scenario("AMQP Publish").repeat(1000) {
+    exec(session => session.set("mykey", "2"),  
     exec(amqp("Publish").publish(queueName, body = Right(body)))
   }
 
@@ -61,10 +65,11 @@ from amqp server is done (sync or async).
     .poolSize(10)
     .confirmMode()
 
-  val body = "{foo:1}")
+  val body = "{foo:1, bar: ${mykey}}")
   val queueName = "myQueue"
 
   val scn = scenario("AMQP Publish(ack)").repeat(1000) {
+    exec(session => session.set("mykey", "2"),
     exec(amqp("Publish").publish(queueName, body = body))
   }
 

--- a/src/main/scala/io/gatling/amqp/infra/AmqpPublisher.scala
+++ b/src/main/scala/io/gatling/amqp/infra/AmqpPublisher.scala
@@ -81,9 +81,10 @@ class AmqpPublisher(actorName: String)(implicit amqp: AmqpProtocol) extends Amqp
     val event = AmqpPublishing(actorName, no, nowMillis, req, session)
     Try {
       val data: Array[Byte] = getData(session, bytes)
+      val sessionData = session.attributes.foldLeft(new String(data))((a, b) => a.replaceAllLiterally("${" + b._1 + "}", b._2.toString)).getBytes()
       val exchangeStr: String = exchange(session).get
       val routingKeyStr: String = routingKey(session).get
-      channel.basicPublish(exchangeStr, routingKeyStr, propertiesEvaluated, data)
+      channel.basicPublish(exchangeStr, routingKeyStr, propertiesEvaluated, sessionData)
       //log.error("message {} published to exchange {}, routing queue {}. (empty exchange with queue in routing key causes publishing directly to queue)", data.toString.blue, exchangeStr.yellow, routingKeyStr.cyan) // import pl.project13.scala.rainbow._
     } match {
       case Success(_) =>
@@ -100,9 +101,10 @@ class AmqpPublisher(actorName: String)(implicit amqp: AmqpProtocol) extends Amqp
     sendEvent(AmqpPublishing(actorName, no, nowMillis, req, session))
     try {
       val data: Array[Byte] = getData(session, bytes)
+      val sessionData = session.attributes.foldLeft(new String(data))((a, b) => a.replaceAllLiterally("${" + b._1 + "}", b._2.toString)).getBytes()
       val exchangeStr: String = exchange(session).get
       val routingKeyStr: String = routingKey(session).get
-      channel.basicPublish(exchangeStr, routingKeyStr, propertiesEvaluated, data)
+      channel.basicPublish(exchangeStr, routingKeyStr, propertiesEvaluated, sessionData)
       //log.error("message {} published to exchange {}, routing queue {}. (empty exchange with queue in routing key causes publishing directly to queue)", data.toString.blue, exchangeStr.yellow, routingKeyStr.cyan) // import pl.project13.scala.rainbow._
     } catch {
       case e: Exception =>


### PR DESCRIPTION
This will allow us to replace the values defined in session inside our message body using same syntax like gatling session API (for instance, ${variable})